### PR TITLE
docs: Fix simple typo, multipication -> multiplication

### DIFF
--- a/secureauth/static/secureauth/js/aes.js
+++ b/secureauth/static/secureauth/js/aes.js
@@ -391,7 +391,7 @@ var slowAES = {
 			return p;
 		},
 		
-		// galois multipication of the 4x4 matrix
+		// galois multiplication of the 4x4 matrix
 		mixColumns:function(state,isInv)
 		{
 			var column = [];
@@ -410,7 +410,7 @@ var slowAES = {
 			return state;
 		},
 
-		// galois multipication of 1 column of the 4x4 matrix
+		// galois multiplication of 1 column of the 4x4 matrix
 		mixColumn:function(column,isInv)
 		{
 			var mult = [];	


### PR DESCRIPTION
There is a small typo in secureauth/static/secureauth/js/aes.js.

Should read `multiplication` rather than `multipication`.

